### PR TITLE
Can now reply to thread messages

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -5,7 +5,7 @@
 [![Quality Score](https://img.shields.io/scrutinizer/g/beyondcode/slack-notification-channel.svg?style=flat-square)](https://scrutinizer-ci.com/g/beyondcode/slack-notification-channel)
 [![Total Downloads](https://img.shields.io/packagist/dt/beyondcode/slack-notification-channel.svg?style=flat-square)](https://packagist.org/packages/beyondcode/slack-notification-channel)
 
-This is the Laravel Slack notification channel, but instead of using incoming webhooks, this channel makes use of OAuth access tokens.
+This is the Laravel Slack notification channel, but instead of using incoming webhooks, this channel makes use of OAuth access tokens. It also allows replies to thread messages.
 
 
 [![https://phppackagedevelopment.com](https://beyondco.de/courses/phppd.jpg)](https://phppackagedevelopment.com)
@@ -36,6 +36,46 @@ public function routeNotificationForSlack()
     ];
 }
 ```
+
+### Replying to Message Threads
+
+Assuming you want to keep track of orders and have your team/bot respond to a single thread of per order placed, this channel allows you to retrieve the API response from the chat.postMessage method inside your notifications. With this you could post messages on order paid, shipped, closed, etc. events to the same thread.
+
+In your order placed event you can have
+
+```php
+public function toSlack($notifiable)
+{
+    return (new SlackMessage)
+        ->content('A new order has been placed');
+}
+
+public function response($response)
+{
+    $response = $response->getBody()->getContents();
+    $this->order->data('slack.thread_ts', json_decode($response, true)['ts']);
+}
+```
+
+And in your order paid event you can have
+
+```php
+public function toSlack($notifiable)
+{
+    $order = $this->order;
+    return (new SlackMessage)
+        ->success()
+        ->content('Order paid')
+        ->threadTimestamp($order->data('slack.thread_ts'))
+           ->attachment(function ($attachment) use ($order) {
+               $attachment->title("Order $order->reference has been paid for.")
+                          ->content('Should now be processed.')
+                          ->action('View Order', route('orders', $order->reference));
+           });
+}
+```
+
+ 
 
 ### Changelog
 

--- a/src/Channels/SlackApiChannel.php
+++ b/src/Channels/SlackApiChannel.php
@@ -55,9 +55,15 @@ class SlackApiChannel
         $this->token = $config['token'];
         $this->channel = $config['channel'] ?? null;
 
-        return $this->http->post(self::API_ENDPOINT, $this->buildJsonPayload(
+        $response = $this->http->post(self::API_ENDPOINT, $this->buildJsonPayload(
             $notification->toSlack($notifiable)
         ));
+
+        if(method_exists($notification, 'response')){
+            return $notification->response($response);
+        }
+
+        return $response;
     }
 
     /**
@@ -76,6 +82,7 @@ class SlackApiChannel
             'unfurl_links' => data_get($message, 'unfurlLinks'),
             'unfurl_media' => data_get($message, 'unfurlMedia'),
             'username' => data_get($message, 'username'),
+            'thread_ts' => data_get($message, 'threadTimestamp'),
         ]);
 
         $payload = [

--- a/src/Messages/SlackMessage.php
+++ b/src/Messages/SlackMessage.php
@@ -6,6 +6,7 @@ use Closure;
 
 class SlackMessage
 {
+
     /**
      * The "level" of the notification (info, success, warning, error).
      *
@@ -82,6 +83,13 @@ class SlackMessage
      * @var array
      */
     public $http = [];
+
+    /**
+     * The attachment's threadTimestamp.
+     *
+     * @var string
+     */
+    public $threadTimestamp;
 
     /**
      * Indicate that the notification gives information about an operation.
@@ -267,6 +275,19 @@ class SlackMessage
     public function http(array $options)
     {
         $this->http = $options;
+
+        return $this;
+    }
+
+    /**
+     * Set the threadTimestamp.
+     *
+     * @param  \DateTimeInterface|\DateInterval|int  $threadTimestamp
+     * @return $this
+     */
+    public function threadTimestamp($threadTimestamp)
+    {
+        $this->threadTimestamp = $threadTimestamp;
 
         return $this;
     }


### PR DESCRIPTION
Can now reply to already existing threads. For an ecommerce store where sales, inquiry requests, etc. must be tracked and actioned per entry, it was necessary to be able to retrieve a post's thread_ts and have it as part of subsequent messages on the same subject.

Slack's message threading is documented [here](https://api.slack.com/docs/message-threading).

Ultimately, notifications can now access the API response recorded [here](https://api.slack.com/methods/chat.postMessage).