### PR TITLE
Allow the thread reply to broadcast to the whole channel

### DIFF
--- a/src/Channels/SlackApiChannel.php
+++ b/src/Channels/SlackApiChannel.php
@@ -83,6 +83,7 @@ class SlackApiChannel
             'unfurl_media' => data_get($message, 'unfurlMedia'),
             'username' => data_get($message, 'username'),
             'thread_ts' => data_get($message, 'threadTimestamp'),
+            'reply_broadcast' => data_get($message, 'threadBroadcast')
         ]);
 
         $payload = [

--- a/src/Messages/SlackMessage.php
+++ b/src/Messages/SlackMessage.php
@@ -92,6 +92,13 @@ class SlackMessage
     public $threadTimestamp;
 
     /**
+     * Broadcasts the thread reply
+     *
+     * @var bool
+     */
+    public $threadBroadcast = false;
+
+    /**
      * Indicate that the notification gives information about an operation.
      *
      * @return $this
@@ -288,6 +295,19 @@ class SlackMessage
     public function threadTimestamp($threadTimestamp)
     {
         $this->threadTimestamp = $threadTimestamp;
+
+        return $this;
+    }
+
+    /**
+     * Set the thread to Broadcast
+     *
+     * @param bool $threadBroadcast
+     * @return $this
+     */
+    public function threadBroadcast($threadBroadcast = true)
+    {
+        $this->threadBroadcast = $threadBroadcast;
 
         return $this;
     }


### PR DESCRIPTION
The thread reply feature is great but my sales team want to see certain reply's broadcast as a new message but still be able to track the thread.

See slack documentation: https://api.slack.com/docs/message-threading#posting_your_reply_back_to_the_channel