### PR TITLE
Fix slack warning

### DIFF
--- a/src/Channels/SlackApiChannel.php
+++ b/src/Channels/SlackApiChannel.php
@@ -110,7 +110,7 @@ class SlackApiChannel
 
 
         $payload['headers'] = [
-            'Content-type' => 'application/json',
+            'Content-type' => 'application/json; charset=UTF-8',
             'Authorization' => 'Bearer '.$this->token,
         ];
 

--- a/tests/SlackApiChannelTest.php
+++ b/tests/SlackApiChannelTest.php
@@ -91,7 +91,7 @@ class SlackApiChannelTest extends TestCase
             new NotificationSlackChannelTestNotification,
             [
                 'headers' => [
-                    'Content-type' => 'application/json',
+                    'Content-type' => 'application/json; charset=UTF-8',
                     'Authorization' => 'Bearer xoxp-token',
                 ],
                 'json' => [
@@ -132,7 +132,7 @@ class SlackApiChannelTest extends TestCase
             new NotificationSlackChannelTestNotificationWithImageIcon,
             [
                 'headers' => [
-                    'Content-type' => 'application/json',
+                    'Content-type' => 'application/json; charset=UTF-8',
                     'Authorization' => 'Bearer xoxp-token',
                 ],
                 'json' => [

--- a/tests/SlackApiChannelTest.php
+++ b/tests/SlackApiChannelTest.php
@@ -170,7 +170,7 @@ class SlackApiChannelTest extends TestCase
             new NotificationSlackChannelTestNotificationWithDefaultChannel,
             [
                 'headers' => [
-                    'Content-type' => 'application/json',
+                    'Content-type' => 'application/json; charset=UTF-8',
                     'Authorization' => 'Bearer xoxp-token',
                 ],
                 'json' => [
@@ -208,7 +208,7 @@ class SlackApiChannelTest extends TestCase
             new NotificationSlackChannelWithoutOptionalFieldsTestNotification,
             [
                 'headers' => [
-                    'Content-type' => 'application/json',
+                    'Content-type' => 'application/json; charset=UTF-8',
                     'Authorization' => 'Bearer xoxp-token',
                 ],
                 'json' => [
@@ -239,7 +239,7 @@ class SlackApiChannelTest extends TestCase
             new NotificationSlackChannelWithAttachmentFieldBuilderTestNotification,
             [
                 'headers' => [
-                    'Content-type' => 'application/json',
+                    'Content-type' => 'application/json; charset=UTF-8',
                     'Authorization' => 'Bearer xoxp-token',
                 ],
                 'json' => [


### PR DESCRIPTION
Right now whenever a notification is sent, slack returns success with a warning in the response. To fix this we need to add the charset.

```
(...)
"warning":"missing_charset","response_metadata":{"warnings":["missing_charset"]
(...)
```

Docs: https://api.slack.com/methods/chat.postMessage#:~:text=long%20messages.-,missing_charset,-The%20method%20was