### PR TITLE
Add Laravel 10 Support

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -34,6 +34,24 @@ jobs:
             laravel: 10.*
           - php: 8.0
             laravel: 10.*
+          - php: 8.1
+            laravel: 6.*
+            dependency-version: prefer-lowest
+          - php: 8.1
+            laravel: 7.*
+            dependency-version: prefer-lowest
+          - php: 8.1
+            laravel: 8.*
+            dependency-version: prefer-lowest
+          - php: 8.2
+            laravel: 6.*
+            dependency-version: prefer-lowest
+          - php: 8.2
+            laravel: 7.*
+            dependency-version: prefer-lowest
+          - php: 8.2
+            laravel: 8.*
+            dependency-version: prefer-lowest
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }} - ${{ matrix.os }}
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -9,7 +9,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        php: [7.4, 7.3, 8.0, 8.1]
+        php: [7.3, 7.4, 8.0, 8.1]
         laravel: [6.*, 7.*, 8.*, 9.*, 10.*]
         dependency-version: [prefer-lowest, prefer-stable]
         include:
@@ -23,6 +23,13 @@ jobs:
               testbench: 5.*
           -   laravel: 6.*
               testbench: 4.*
+        exclude:
+          - php: 7.3
+            laravel: [9.*, 10.*]
+          - php: 7.4
+            laravel: [9.*, 10.*]
+          - php: 8.0
+            laravel: 10.*
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }} - ${{ matrix.os }}
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -39,10 +39,10 @@ jobs:
 
     steps:
       -   name: Checkout code
-          uses: actions/checkout@v2
+          uses: actions/checkout@v3
 
       -   name: Cache dependencies
-          uses: actions/cache@v2
+          uses: actions/cache@v3
           with:
             path: ~/.composer/cache/files
             key: dependencies-laravel-${{ matrix.laravel }}-php-${{ matrix.php }}-composer-${{ hashFiles('composer.json') }}

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -9,10 +9,12 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        php: [7.4, 7.3, 8.0]
-        laravel: [6.*, 7.*, 8.*, 9.*]
+        php: [7.4, 7.3, 8.0, 8.1]
+        laravel: [6.*, 7.*, 8.*, 9.*, 10.*]
         dependency-version: [prefer-lowest, prefer-stable]
         include:
+          -   laravel: 10.*
+              testbench: 8.*
           -   laravel: 9.*
               testbench: 7.*
           -   laravel: 8.*
@@ -26,10 +28,10 @@ jobs:
 
     steps:
       -   name: Checkout code
-          uses: actions/checkout@v1
+          uses: actions/checkout@v2
 
       -   name: Cache dependencies
-          uses: actions/cache@v1
+          uses: actions/cache@v2
           with:
             path: ~/.composer/cache/files
             key: dependencies-laravel-${{ matrix.laravel }}-php-${{ matrix.php }}-composer-${{ hashFiles('composer.json') }}
@@ -43,7 +45,9 @@ jobs:
 
       -   name: Install dependencies
           run: |
-            composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
+            composer require "orchestra/testbench:${{ matrix.testbench }}" --dev --no-interaction --no-update
+            composer require "laravel/framework:${{ matrix.laravel }}" --no-interaction --no-update
             composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction --no-suggest
+
       -   name: Execute tests
           run: vendor/bin/phpunit

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -9,7 +9,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        php: [7.3, 7.4, 8.0, 8.1]
+        php: [7.3, 7.4, 8.0, 8.1, 8.2]
         laravel: [6.*, 7.*, 8.*, 9.*, 10.*]
         dependency-version: [prefer-lowest, prefer-stable]
         include:
@@ -25,9 +25,13 @@ jobs:
               testbench: 4.*
         exclude:
           - php: 7.3
-            laravel: [9.*, 10.*]
+            laravel: 9.*
+          - php: 7.3
+            laravel: 10.*
           - php: 7.4
-            laravel: [9.*, 10.*]
+            laravel: 9.*
+          - php: 7.4
+            laravel: 10.*
           - php: 8.0
             laravel: 10.*
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 /vendor
 /.idea
+/.phpunit.cache
+.phpunit.result.cache
 composer.phar
 composer.lock
 .DS_Store

--- a/composer.json
+++ b/composer.json
@@ -10,13 +10,13 @@
         }
     ],
     "require": {
-        "php": "^7.3.0|^8.0",
+        "php": "^7.3.0|^8.0|^8.1",
         "guzzlehttp/guzzle": "^6.0|^7.0",
-        "illuminate/notifications": "^6.0|^7.0|^8.0|^9.0"
+        "illuminate/notifications": "^6.0|^7.0|^8.0|^9.0|^10.0"
     },
     "require-dev": {
         "mockery/mockery": "^1.3",
-        "phpunit/phpunit": "^8.0|^9.0"
+        "phpunit/phpunit": "^8.0|^9.0|^10.0"
     },
     "autoload": {
         "psr-4": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,25 +1,25 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit backupGlobals="false"
-         backupStaticAttributes="false"
-         beStrictAboutTestsThatDoNotTestAnything="true"
-         bootstrap="vendor/autoload.php"
-         colors="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
-         processIsolation="false"
-         stopOnError="false"
-         stopOnFailure="false"
-         verbose="true"
+<phpunit
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    backupGlobals="false"
+    beStrictAboutTestsThatDoNotTestAnything="true"
+    bootstrap="vendor/autoload.php"
+    colors="true"
+    processIsolation="false"
+    stopOnError="false"
+    stopOnFailure="false"
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.0/phpunit.xsd"
+    cacheDirectory=".phpunit.cache"
+    backupStaticProperties="false"
 >
-    <testsuites>
-        <testsuite name="Slack Channel Test Suite">
-            <directory suffix="Test.php">./tests</directory>
-        </testsuite>
-    </testsuites>
-    <filter>
-        <whitelist processUncoveredFilesFromWhitelist="true">
-            <directory suffix=".php">./src</directory>
-        </whitelist>
-    </filter>
+  <coverage>
+    <include>
+      <directory suffix=".php">./src</directory>
+    </include>
+  </coverage>
+  <testsuites>
+    <testsuite name="Slack Channel Test Suite">
+      <directory suffix="Test.php">./tests</directory>
+    </testsuite>
+  </testsuites>
 </phpunit>

--- a/tests/SlackApiChannelTest.php
+++ b/tests/SlackApiChannelTest.php
@@ -55,14 +55,14 @@ class SlackApiChannelTest extends TestCase
         $this->slackChannel->send(new NotificationSlackChannelTestNotifiable, $notification);
     }
 
-    public function payloadDataProvider()
+    public static function payloadDataProvider()
     {
         return [
-            'payloadWithIcon' => $this->getPayloadWithIcon(),
-            'payloadWithImageIcon' => $this->getPayloadWithImageIcon(),
-            'payloadWithDefaultChannel' => $this->getPayloadWithDefaultChannel(),
-            'payloadWithoutOptionalFields' => $this->getPayloadWithoutOptionalFields(),
-            'payloadWithAttachmentFieldBuilder' => $this->getPayloadWithAttachmentFieldBuilder(),
+            'payloadWithIcon' => self::getPayloadWithIcon(),
+            'payloadWithImageIcon' => self::getPayloadWithImageIcon(),
+            'payloadWithDefaultChannel' => self::getPayloadWithDefaultChannel(),
+            'payloadWithoutOptionalFields' => self::getPayloadWithoutOptionalFields(),
+            'payloadWithAttachmentFieldBuilder' => self::getPayloadWithAttachmentFieldBuilder(),
         ];
     }
 
@@ -85,7 +85,7 @@ class SlackApiChannelTest extends TestCase
         );
     }
 
-    private function getPayloadWithIcon()
+    private static function getPayloadWithIcon()
     {
         return [
             new NotificationSlackChannelTestNotification,
@@ -126,7 +126,7 @@ class SlackApiChannelTest extends TestCase
         ];
     }
 
-    private function getPayloadWithImageIcon()
+    private static function getPayloadWithImageIcon()
     {
         return [
             new NotificationSlackChannelTestNotificationWithImageIcon,
@@ -164,7 +164,7 @@ class SlackApiChannelTest extends TestCase
         ];
     }
 
-    private function getPayloadWithDefaultChannel()
+    private static function getPayloadWithDefaultChannel()
     {
         return [
             new NotificationSlackChannelTestNotificationWithDefaultChannel,
@@ -202,7 +202,7 @@ class SlackApiChannelTest extends TestCase
         ];
     }
 
-    private function getPayloadWithoutOptionalFields()
+    private static function getPayloadWithoutOptionalFields()
     {
         return [
             new NotificationSlackChannelWithoutOptionalFieldsTestNotification,
@@ -233,7 +233,7 @@ class SlackApiChannelTest extends TestCase
         ];
     }
 
-    public function getPayloadWithAttachmentFieldBuilder()
+    public static function getPayloadWithAttachmentFieldBuilder()
     {
         return [
             new NotificationSlackChannelWithAttachmentFieldBuilderTestNotification,


### PR DESCRIPTION
This PR adds support for Laravel 10, and updates the workflow to ensure all tests pass for specific Laravel/PHP Versions.

Additionally fixes a deprecation warning in for `Data Provider method BeyondCode\SlackNotificationChannel\Tests\SlackApiChannelTest::payloadDataProvider() is not static`.