### PR TITLE
Resolve instance from container

### DIFF
--- a/src/SlackChannelServiceProvider.php
+++ b/src/SlackChannelServiceProvider.php
@@ -18,7 +18,7 @@ class SlackChannelServiceProvider extends ServiceProvider
     {
         Notification::resolved(function (ChannelManager $service) {
             $service->extend('slack', function ($app) {
-                return new Channels\SlackApiChannel(new HttpClient);
+                return $app->make(Channels\SlackApiChannel::class);
             });
         });
     }


### PR DESCRIPTION
This allows applications to customize the HTTP client used by the channel.

For instance, I might want to set a 10 second timeout specifically on the Slack notifications channel, but not for other channels.

I can now do this in my app service provider.

```php
$this->app->when(SlackApiChannel::class)
    ->needs(Client::class)
    ->give(fn () => new Client(['timeout' => 10]));

```